### PR TITLE
Generalise `substitute`

### DIFF
--- a/src/Bound.purs
+++ b/src/Bound.purs
@@ -37,12 +37,8 @@ import Data.Monoid (class Monoid, mempty)
 import Prelude
 
 
-substitute :: forall f a. (Monad f, Eq a) => a -> f a -> f a -> f a
-substitute v s t = do
-    x <- t
-    if x == v
-        then s
-        else pure x
+substitute :: forall f a. (Apply f, Eq a) => a -> f a -> f a -> f a
+substitute v = lift2 (\s x -> if x == v then s else x)
 
 substituteVar :: forall f a. (Functor f, Eq a) => a -> a -> f a -> f a
 substituteVar v s = map (\x -> if x == v then s else x)


### PR DESCRIPTION
Hello!

I'm certainly not an expert on Kmett's work - I found this library while trying to understand Bound myself - but I think the `substitute` method can be expressed using only an `Apply f`, rather than a `Monad`. I suspect this wasn't done in the Haskell version because it was released back in the days when `Applicative` and `Monad` weren't related properly, and I don't think Haskell has an `Apply` typeclass even now!

Anyway, below is the implementation. I _love_ the symmetry with the `substituteVar` method.